### PR TITLE
Feature/output current admin enabled

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ jobs:
       if: always()
       with:
         access-token: ${{ secrets.ACCESS_TOKEN }}
-        enforce_admins: false
+        enforce-admins: false
     - name: Test empty commit
       run: |
         git config --global user.email "bot@echosoft.uk"
@@ -52,4 +52,4 @@ jobs:
       if: always()
       with:
         access-token: ${{ secrets.ACCESS_TOKEN }}
-        enforce_admins: true
+        enforce-admins: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,8 +33,8 @@ jobs:
       uses: benjefferies/branch-protection-bot@master
       if: always()
       with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
-        enforce-admins: false
+        access_token: ${{ secrets.ACCESS_TOKEN }}
+        enforce_admins: false
     - name: Test empty commit
       run: |
         git config --global user.email "bot@echosoft.uk"
@@ -46,10 +46,10 @@ jobs:
       uses: benjefferies/branch-protection-bot@master
       if: always()
       with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
+        access_token: ${{ secrets.ACCESS_TOKEN }}
     - name: Force enable "include administrators" branch protection
       uses: benjefferies/branch-protection-bot@master
       if: always()
       with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
-        enforce-admins: true
+        access_token: ${{ secrets.ACCESS_TOKEN }}
+        enforce_admins: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Branch Protection Bot
-A bot tool to temporarily disable and re-enable "Include administrators" option in branch protection
+A bot tool to temporarily disable and re-enable `Include administrators` option in branch protection
 
 Github doesn't have a way to give a Bot access to override the branch protection, specifically if you [include administrators](https://github.com/isaacs/github/issues/1390).
 The only possible solution is to disable the `include administrators` option. This increases risk of accidental pushes to master from administrators (I've done it a few times).
@@ -23,6 +23,7 @@ docker run -e ACCESS_TOKEN=abc123 -e BRANCH=master -e REPO=branch-protection-bot
 
 ```
 - name: Temporarily disable "include administrators" branch protection
+  id: disable_include_admins
   uses: benjefferies/branch-protection-bot@master
   if: always()
   with:
@@ -68,7 +69,14 @@ Number of times to retry before exiting. Default `5`.
 
 ##### `enforce_admins`
 
-If you want to pin the state of "Include administrators" for a step in the workflow.
+If you want to pin the state of `Include administrators` for a step in the workflow.
+
+#### Outputs
+
+##### `current-status`
+
+Output the current branch protection status of `Include administrators` prior to any change.
+You can retrieve it from any next step in your job using: `${{ steps.disable_include_admins.outputs.current-status }}`.
 
 ## Github repository settings
 The Bot account must be an administrator.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run -e ACCESS_TOKEN=abc123 -e BRANCH=master -e REPO=branch-protection-bot
   uses: benjefferies/branch-protection-bot@master
   if: always()
   with:
-    access-token: ${{ secrets.ACCESS_TOKEN }}
+    access_token: ${{ secrets.ACCESS_TOKEN }}
     branch: ${{ github.event.repository.default_branch }}
     
 - name: Deploy
@@ -38,7 +38,7 @@ docker run -e ACCESS_TOKEN=abc123 -e BRANCH=master -e REPO=branch-protection-bot
   uses: benjefferies/branch-protection-bot@master
   if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
   with:
-    access-token: ${{ secrets.ACCESS_TOKEN }}
+    access_token: ${{ secrets.ACCESS_TOKEN }}
     owner: benjefferies
     repo: branch-protection-bot
     branch: ${{ github.event.repository.default_branch }}
@@ -46,7 +46,7 @@ docker run -e ACCESS_TOKEN=abc123 -e BRANCH=master -e REPO=branch-protection-bot
 
 #### Inputs
 
-##### `access-token`
+##### `access_token`
 
 **Required** Github access token. https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line. Requires full repository access scope
 
@@ -66,16 +66,16 @@ Branch name. Default `"master"`
 
 Number of times to retry before exiting. Default `5`.
 
-##### `enforce-admins`
+##### `enforce_admins`
 
 If you want to pin the state of `Include administrators` for a step in the workflow.
 
 #### Outputs
 
-##### `initial-status`
+##### `initial_status`
 
 Output the current branch protection status of `Include administrators` prior to any change.
-You can retrieve it from any next step in your job using: `${{ steps.disable_include_admins.outputs.initial-status }}`.
+You can retrieve it from any next step in your job using: `${{ steps.disable_include_admins.outputs.initial_status }}`.
 This would help you to restore the initial setting this way:
 
 ```yaml
@@ -85,9 +85,9 @@ steps:
     uses: benjefferies/branch-protection-bot@master
     if: always()
     with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
+        access_token: ${{ secrets.ACCESS_TOKEN }}
         branch: ${{ github.event.repository.default_branch }}
-        enforce-admins: false
+        enforce_admins: false
     
     - ...
 
@@ -95,9 +95,9 @@ steps:
     uses: benjefferies/branch-protection-bot@master
     if: always() # Force to always run this step to ensure "include administrators" is always turned back on
     with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
+        access_token: ${{ secrets.ACCESS_TOKEN }}
         branch: ${{ github.event.repository.default_branch }}
-        enforce-admins: ${{ steps.disable_include_admins.outputs.initial-status }}
+        enforce_admins: ${{ steps.disable_include_admins.outputs.initial_status }}
 ```
 
 ## Github repository settings

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ docker run -e ACCESS_TOKEN=abc123 -e BRANCH=master -e REPO=branch-protection-bot
 
 ```
 - name: Temporarily disable "include administrators" branch protection
-  id: disable_include_admins
   uses: benjefferies/branch-protection-bot@master
   if: always()
   with:
@@ -73,10 +72,33 @@ If you want to pin the state of `Include administrators` for a step in the workf
 
 #### Outputs
 
-##### `current-status`
+##### `initial-status`
 
 Output the current branch protection status of `Include administrators` prior to any change.
-You can retrieve it from any next step in your job using: `${{ steps.disable_include_admins.outputs.current-status }}`.
+You can retrieve it from any next step in your job using: `${{ steps.disable_include_admins.outputs.initial-status }}`.
+This would help you to restore the initial setting this way:
+
+```yaml
+steps:
+    - name: "Temporarily disable 'include administrators' default branch protection"
+    id: disable_include_admins
+    uses: benjefferies/branch-protection-bot@master
+    if: always()
+    with:
+        access-token: ${{ secrets.ACCESS_TOKEN }}
+        branch: ${{ github.event.repository.default_branch }}
+        enforce-admins: false
+    
+    - ...
+
+    - name: "Restore 'include administrators' default branch protection"
+    uses: benjefferies/branch-protection-bot@master
+    if: always() # Force to always run this step to ensure "include administrators" is always turned back on
+    with:
+        access-token: ${{ secrets.ACCESS_TOKEN }}
+        branch: ${{ github.event.repository.default_branch }}
+        enforce-admins: ${{ steps.disable_include_admins.outputs.initial-status }}
+```
 
 ## Github repository settings
 The Bot account must be an administrator.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Branch name. Default `"master"`
 
 Number of times to retry before exiting. Default `5`.
 
-##### `enforce_admins`
+##### `enforce-admins`
 
 If you want to pin the state of `Include administrators` for a step in the workflow.
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   enforce_admins:
     description: 'Flag to explicitly enable or disable "Include administrators"'
     required: false
+outputs:
+  current-status:
+    description: "Output the current branch protection status of 'Include administrators' prior to any change"
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Number of times to retry before exiting'
     required: false
     default: 5
-  enforce_admins:
+  enforce-admins:
     description: 'Flag to explicitly enable or disable "Include administrators"'
     required: false
 outputs:
@@ -39,4 +39,4 @@ runs:
     REPO: ${{ inputs.repo }}
     BRANCH: ${{ inputs.branch }}
     RETRIES: ${{ inputs.retries }}
-    ENFORCE_ADMINS: ${{ inputs.enforce_admins }}
+    ENFORCE_ADMINS: ${{ inputs.enforce-admins }}

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: blue
   icon: unlock
 inputs:
-  access-token:
+  access_token:
     description: 'Github access token. https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line'
     required: true
   owner:
@@ -23,20 +23,20 @@ inputs:
     description: 'Number of times to retry before exiting'
     required: false
     default: 5
-  enforce-admins:
+  enforce_admins:
     description: 'Flag to explicitly enable or disable "Include administrators"'
     required: false
 outputs:
-  initial-status:
+  initial_status:
     description: "Output the current branch protection status of 'Include administrators' prior to any change"
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    ACCESS_TOKEN: ${{ inputs.access-token }}
+    ACCESS_TOKEN: ${{ inputs.access_token }}
     OWNER: ${{ inputs.owner }}
     REPO: ${{ inputs.repo }}
     BRANCH: ${{ inputs.branch }}
     RETRIES: ${{ inputs.retries }}
-    ENFORCE_ADMINS: ${{ inputs.enforce-admins }}
+    ENFORCE_ADMINS: ${{ inputs.enforce_admins }}

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: 'Flag to explicitly enable or disable "Include administrators"'
     required: false
 outputs:
-  current-status:
+  initial-status:
     description: "Output the current branch protection status of 'Include administrators' prior to any change"
 
 runs:

--- a/run.py
+++ b/run.py
@@ -22,7 +22,7 @@ def toggle_enforce_admin(options):
     protection = get_protection(access_token, branch_name, owner, repo_name)
     print(f"Enforce admins branch protection enabled? {protection.enforce_admins.enabled}")
     # save the current status for use later on if desired
-    print(f"::set-output name=current-status::{protection.enforce_admins.enabled}")
+    print(f"::set-output name=initial-status::{protection.enforce_admins.enabled}")
     print(f"Setting enforce admins branch protection to {enforce_admins if enforce_admins is not None else not protection.enforce_admins.enabled}")
     for i in range(retries):
         try:

--- a/run.py
+++ b/run.py
@@ -78,6 +78,6 @@ if __name__ == '__main__':
     p.add_argument('--github_repository', env_var='GITHUB_REPOSITORY', required=False, default='', help='Owner and repo. For example benjefferies/branch-protection-bot for https://github.com/benjefferies/branch-protection-bot')
     p.add_argument('-b', '--branch', env_var='BRANCH', default='master', help='Branch name')
     p.add_argument('--retries', env_var='RETRIES', default=5, help='Number of times to retry before exiting')
-    p.add_argument('--enforce_admins', env_var='ENFORCE_ADMINS', default=None, help='Flag to explicitly enable or disable "Include administrators"')
+    p.add_argument('--enforce-admins', env_var='ENFORCE_ADMINS', default=None, help='Flag to explicitly enable or disable "Include administrators"')
 
     toggle_enforce_admin(p.parse_args())

--- a/run.py
+++ b/run.py
@@ -21,6 +21,8 @@ def toggle_enforce_admin(options):
     print(f"Getting branch protection settings for {owner}/{repo_name}")
     protection = get_protection(access_token, branch_name, owner, repo_name)
     print(f"Enforce admins branch protection enabled? {protection.enforce_admins.enabled}")
+    # save the current status for use later on if desired
+    print(f"::set-output name=current-status::{protection.enforce_admins.enabled}")
     print(f"Setting enforce admins branch protection to {enforce_admins if enforce_admins is not None else not protection.enforce_admins.enabled}")
     for i in range(retries):
         try:

--- a/run.py
+++ b/run.py
@@ -22,7 +22,7 @@ def toggle_enforce_admin(options):
     protection = get_protection(access_token, branch_name, owner, repo_name)
     print(f"Enforce admins branch protection enabled? {protection.enforce_admins.enabled}")
     # save the current status for use later on if desired
-    print(f"::set-output name=initial-status::{protection.enforce_admins.enabled}")
+    print(f"::set-output name=initial_status::{protection.enforce_admins.enabled}")
     print(f"Setting enforce admins branch protection to {enforce_admins if enforce_admins is not None else not protection.enforce_admins.enabled}")
     for i in range(retries):
         try:


### PR DESCRIPTION
Output the current status of 'Include administrators' just before changing it.
That way you can restore it at the end of the workflow.